### PR TITLE
Add `path` to credentials file standard

### DIFF
--- a/SS3-Unified_Credentials_File.md
+++ b/SS3-Unified_Credentials_File.md
@@ -39,6 +39,7 @@ The follow values are supported for each connection:
 * `token` should be set to the authorization token (currently only supported on the public server).
 * `username` is the screeps username, and is only supported on private servers.
 * `password` is the screeps password, and is only supported on private servers.
+* `path` is an optional URL prefix (eg `/ptr` or `/season`) to be used to specify which environment to upload to.
 
 It may have a top level `configs` object that contains individual app specific configs.
 
@@ -51,11 +52,16 @@ servers:
     host: screeps.com
     secure: true
     token: '35a345b9-bc6b-4855-8566-66b341913f9b'
+  seasonal:
+    host: screeps.com
+    secure: true
+    token: '35a345b9-bc6b-4855-8566-66b341913f9b'
+    path: /season
   ptr:
     host: screeps.com
     secure: true
     token: '17f70980-eceb-46ba-a4c3-9677a1570f06'
-    ptr: true
+    path: /ptr
   screepsplus:
     host: screepspl.us
     secure: true


### PR DESCRIPTION
Proposing adding `path` as a server-level option to the config standard, and removing the currently-just-in-the-example `ptr` key, matching the change from a few years back to gulp-screeps to support seasonal (https://github.com/screepers/gulp-screeps/pull/2).

For a look at the ecosystem, `rollup-plugin-screeps` also uses `path` but has a much different config format from this standard; `grunt-screeps` takes a different approach with its `server` field with magic values associated to hardcoded values (and `cargo-screeps` for us rustaceans uses `prefix` but it doesn't support this format whatsoever at the moment - I maintain that tool so I might add that down the line).